### PR TITLE
Update aws-sdk to v3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     active_elastic_job (2.0.0)
-      aws-sdk (~> 2)
+      aws-sdk-sqs (~> 1)
       rails (>= 4.2)
 
 GEM
@@ -46,12 +46,15 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.2)
-    aws-sdk (2.3.22)
-      aws-sdk-resources (= 2.3.22)
-    aws-sdk-core (2.3.22)
+    aws-partitions (1.26.0)
+    aws-sdk-core (3.6.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.22)
-      aws-sdk-core (= 2.3.22)
+    aws-sdk-sqs (1.2.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     benchmark-ips (2.3.0)
     builder (3.2.2)
     byebug (8.2.2)
@@ -67,7 +70,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
-    jmespath (1.3.0)
+    jmespath (1.3.1)
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -160,4 +163,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.11.2
+   1.15.4

--- a/active-elastic-job.gemspec
+++ b/active-elastic-job.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-sqs', '~> 1'
   spec.add_dependency 'rails', '>= 4.2'
 end

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -113,7 +113,7 @@ module ActiveJob
         private
 
         def aws_client_verifies_md5_digests?
-          Gem::Version.new(Aws::VERSION) >= Gem::Version.new('2.2.19'.freeze)
+          Gem::Version.new(Aws::CORE_GEM_VERSION) >= Gem::Version.new('2.2.19'.freeze)
         end
 
         def build_message(queue_name, serialized_job, timestamp)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'aws-sdk'
+require 'aws-sdk-sqs'
 require 'open-uri'
 require 'active_job'
 require 'active_job/queue_adapters'


### PR DESCRIPTION
Update to latest version of the aws-sdk, version 3 introduces
modularized gems for the services so we can use only sqs instead of
relying on all the aws services.